### PR TITLE
Closed stamp redeem

### DIFF
--- a/src/components/userpanel/JumboStampSystem.tsx
+++ b/src/components/userpanel/JumboStampSystem.tsx
@@ -589,7 +589,7 @@ const JumboStampSystem = () => {
                   onMouseLeave={() => setHoverActive(false)}
                 >
                   <RewardsHeader>
-                    Redemption will be made starting July 5th
+                    Redemption has ended, thank you for your support
                     {/* <RewardsDate>07/05/2023</RewardsDate> */}
                   </RewardsHeader>
                 </RewardsHeaderContainer>

--- a/src/components/userpanel/StampRedeem.tsx
+++ b/src/components/userpanel/StampRedeem.tsx
@@ -1,10 +1,13 @@
-import React, { useState, useEffect } from "react";
-import { useSelector } from "react-redux";
+import React, {
+  useState,
+  // , useEffect
+} from "react";
+// import { useSelector } from "react-redux";
 import styled from "styled-components";
-import { selectGlobalAccount, selectStampsHeld } from "../../state/uiSlice";
+// import { selectGlobalAccount, selectStampsHeld } from "../../state/uiSlice";
 import ButtonBlue from "./ButtonBlue";
 import DecorHorizontal from "./DecorHorizontal";
-import { postDiscount } from "../../contracts/functions";
+// import { postDiscount } from "../../contracts/functions";
 
 const RedeemContainer = styled.div`
   display: flex;
@@ -37,41 +40,42 @@ const ShippingHighlight = styled.span`
 `;
 
 const StampRedeem = () => {
-  const walletAddress = useSelector(selectGlobalAccount);
+  // const walletAddress = useSelector(selectGlobalAccount);
 
-  const url = process.env.REACT_APP_STORE_URL;
-  const aikoAPI = process.env.REACT_APP_EXPRESS_SERVER_URL;
+  // const url = process.env.REACT_APP_STORE_URL;
+  // const aikoAPI = process.env.REACT_APP_EXPRESS_SERVER_URL;
   const [disabled, setDisabled] = useState(false);
-  const [encryptedObject, setEncryptedObject] = useState("");
+  // const [encryptedObject, setEncryptedObject] = useState("");
 
-  const [key] = useState("aikoaikoaiko");
+  // const [key] = useState("aikoaikoaiko");
 
-  const stampsHeld = useSelector(selectStampsHeld);
+  // const stampsHeld = useSelector(selectStampsHeld);
 
-  useEffect(() => {
-    if (encryptedObject) {
-      window.open(`${url}?coupon=${encryptedObject}`, "_blank");
-    }
-  }, [encryptedObject, key]);
+  // useEffect(() => {
+  //   if (encryptedObject) {
+  //     window.open(`${url}?coupon=${encryptedObject}`, "_blank");
+  //   }
+  // }, [encryptedObject, key]);
 
   const handleButtonClick = async () => {
-    if (stampsHeld >= 3) {
-      const encryptedObject = await postDiscount(
-        aikoAPI ?? "",
-        walletAddress,
-        stampsHeld,
-        key
-      );
-      setEncryptedObject(encryptedObject);
-    } else {
-      setDisabled(true);
-    }
+    setDisabled(true);
+    // if (stampsHeld >= 3) {
+    //   const encryptedObject = await postDiscount(
+    //     aikoAPI ?? "",
+    //     walletAddress,
+    //     stampsHeld,
+    //     key
+    //   );
+    //   setEncryptedObject(encryptedObject);
+    // } else {
+    //   setDisabled(true);
+    // }
   };
 
   return (
     <RedeemContainer>
       <ShippingText>
-        <ShippingHighlight> Redeem NOW</ShippingHighlight>
+        <ShippingHighlight>CLOSED</ShippingHighlight>
       </ShippingText>
       <ButtonBlue
         disabled={disabled}


### PR DESCRIPTION
## Remove Stamp Redemption Functionality After Redemption Period End

This PR is in response to the completion of the stamp redemption period. As the redemption period has now ended, it is necessary to disable the associated functionality on our platform to avoid confusion and misuse. The changes in this PR reflect this requirement.

In the course of our project, we encountered an issue with Shopify's side, where a new coupon could be generated after placing an order. Although this problem did not disrupt our operations or user experience during the redemption period, it has been a valuable lesson for our future development process.

### Changes:

1. Removed all stamp redemption functionality.
2. Updated all user interfaces to remove references to stamp redemption.

### Test Plan:

1. Confirm that users cannot access any stamp redemption features.
2. Verify that all user interfaces have been updated to reflect these changes.

### Lessons Learned:

This project has emphasized the importance of considering all potential user actions, including order placement, in our testing process. Moving forward, we will work to incorporate these learnings into our development and testing processes to ensure a smoother user experience and reduce the likelihood of unforeseen issues.